### PR TITLE
Shell: Update background path when changing locales

### DIFF
--- a/update.c
+++ b/update.c
@@ -19,7 +19,7 @@ find_dir_entry (XdgDirEntry *entries, const char *type)
   for (i = 0; entries[i].type != NULL; i++)
     {
       if (strcmp (entries[i].type, type) == 0)
-	return &entries[i];
+        return &entries[i];
     }
   return NULL;
 }
@@ -32,7 +32,7 @@ find_dir_entry_by_path (XdgDirEntry *entries, const char *path)
   for (i = 0; entries[i].type != NULL; i++)
     {
       if (strcmp (entries[i].path, path) == 0)
-	return &entries[i];
+        return &entries[i];
     }
   return NULL;
 }
@@ -114,16 +114,16 @@ do_run_dialog (GtkListStore *list_store,
   int response;
 
   dialog = gtk_message_dialog_new (NULL, 0,
-				   GTK_MESSAGE_WARNING,
-				   GTK_BUTTONS_NONE,
-				   _("Update standard folders to current language?"));
+                                   GTK_MESSAGE_WARNING,
+                                   GTK_BUTTONS_NONE,
+                                   _("Update standard folders to current language?"));
   gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG (dialog),
-					    _("You have logged in in a new language. You can automatically update the names of some standard folders in your home folder to match this language. The update would change the following folders:"));
+                                            _("You have logged in in a new language. You can automatically update the names of some standard folders in your home folder to match this language. The update would change the following folders:"));
 
   gtk_dialog_add_buttons (GTK_DIALOG (dialog),
-			  _("_Keep Old Names"), GTK_RESPONSE_NO,
-			  _("_Update Names"), GTK_RESPONSE_YES,
-			  NULL);
+                          _("_Keep Old Names"), GTK_RESPONSE_NO,
+                          _("_Update Names"), GTK_RESPONSE_YES,
+                          NULL);
 
   gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_NO);
 
@@ -134,10 +134,10 @@ do_run_dialog (GtkListStore *list_store,
 
   scrolledwindow = gtk_scrolled_window_new (NULL, NULL);
   gtk_scrolled_window_set_policy (GTK_SCROLLED_WINDOW (scrolledwindow),
-				  GTK_POLICY_NEVER,
-				  GTK_POLICY_NEVER);
+                                  GTK_POLICY_NEVER,
+                                  GTK_POLICY_NEVER);
   gtk_scrolled_window_set_shadow_type (GTK_SCROLLED_WINDOW (scrolledwindow),
-				       GTK_SHADOW_IN);  
+                                       GTK_SHADOW_IN);  
   
   gtk_box_pack_start (GTK_BOX (vbox), scrolledwindow, TRUE, TRUE, 0);
   
@@ -148,18 +148,18 @@ do_run_dialog (GtkListStore *list_store,
 
   cell = gtk_cell_renderer_text_new ();
   gtk_tree_view_insert_column_with_attributes (GTK_TREE_VIEW (treeview),
-					       -1, _("Current folder name"),
-					       cell,
-					       "text", 0,
-					       NULL);
+                                               -1, _("Current folder name"),
+                                               cell,
+                                               "text", 0,
+                                               NULL);
   gtk_tree_view_insert_column_with_attributes (GTK_TREE_VIEW (treeview),
-					       -1, _("New folder name"),
-					       cell,
-					       "text", 1,
-					       NULL);
+                                               -1, _("New folder name"),
+                                               cell,
+                                               "text", 1,
+                                               NULL);
 
   gtk_container_add (GTK_CONTAINER (scrolledwindow),
-		     treeview);
+                     treeview);
 
   gtk_widget_show_all (scrolledwindow);
 
@@ -238,47 +238,47 @@ update_locale (XdgDirEntry *old_entries)
   for (i = 0; old_entries[i].type != NULL; i++)
     {
       for (j = 0; new_entries[j].type != NULL; j++)
-	{
-	  if (strcmp (old_entries[i].type, new_entries[j].type) == 0)
-	    break;
-	}
+        {
+          if (strcmp (old_entries[i].type, new_entries[j].type) == 0)
+            break;
+        }
       if (new_entries[j].type != NULL &&
-	  strcmp (old_entries[i].path, new_entries[j].path) != 0)
-	{
-	  char *from, *to;
-	  from = g_filename_display_name (old_entries[i].path);
-	  to = g_filename_display_name (new_entries[j].path);
+          strcmp (old_entries[i].path, new_entries[j].path) != 0)
+        {
+          char *from, *to;
+          from = g_filename_display_name (old_entries[i].path);
+          to = g_filename_display_name (new_entries[j].path);
 
-	  gtk_list_store_append (list_store, &iter);
-	  gtk_list_store_set (list_store, &iter,
-			      0, from, 1, to, -1);
-	  
-	  g_free (from);
-	  g_free (to);
-	  
-	  has_changes = TRUE;
-	}
+          gtk_list_store_append (list_store, &iter);
+          gtk_list_store_set (list_store, &iter,
+                              0, from, 1, to, -1);
+          
+          g_free (from);
+          g_free (to);
+          
+          has_changes = TRUE;
+        }
     }
   for (j = 0; new_entries[j].type != NULL; j++)
     {
       for (i = 0; old_entries[i].type != NULL; i++)
-	{
-	  if (strcmp (old_entries[i].type, new_entries[j].type) == 0)
-	    break;
-	}
+        {
+          if (strcmp (old_entries[i].type, new_entries[j].type) == 0)
+            break;
+        }
       if (old_entries[i].type == NULL)
-	{
-	  char *to;
-	  to = g_filename_display_name (new_entries[j].path);
+        {
+          char *to;
+          to = g_filename_display_name (new_entries[j].path);
 
-	  gtk_list_store_append (list_store, &iter);
-	  gtk_list_store_set (list_store, &iter,
-			      0, "-", 1, to, -1);
+          gtk_list_store_append (list_store, &iter);
+          gtk_list_store_set (list_store, &iter,
+                              0, "-", 1, to, -1);
 
-	  g_free (to);
-	  
-	  has_changes = TRUE;
-	}
+          g_free (to);
+          
+          has_changes = TRUE;
+        }
     }
 
   if (!has_changes)
@@ -309,37 +309,37 @@ update_locale (XdgDirEntry *old_entries)
         cmdline = XDG_USER_DIRS_UPDATE " --force";
 
       if (!g_spawn_command_line_sync (cmdline, NULL, NULL, &exit_status, NULL) ||
-	  !WIFEXITED(exit_status) ||
-	  WEXITSTATUS(exit_status) != 0)
-	{
-	  GtkWidget *error;
+          !WIFEXITED(exit_status) ||
+          WEXITSTATUS(exit_status) != 0)
+        {
+          GtkWidget *error;
 
-	  error = gtk_message_dialog_new (NULL, 0,
-					  GTK_MESSAGE_ERROR,
-					  GTK_BUTTONS_OK,
-					  _("There was an error updating the folders"));
-	  
-	  gtk_dialog_run (GTK_DIALOG (error));
-	  gtk_widget_destroy (error);
-	}
+          error = gtk_message_dialog_new (NULL, 0,
+                                          GTK_MESSAGE_ERROR,
+                                          GTK_BUTTONS_OK,
+                                          _("There was an error updating the folders"));
+          
+          gtk_dialog_run (GTK_DIALOG (error));
+          gtk_widget_destroy (error);
+        }
       else
-	{
-	  /* Change succeeded, remove any leftover empty directories */
-	  for (i = 0; old_entries[i].type != NULL; i++)
-	    {
-	      /* Never remove homedir */
-	      if (strcmp (old_entries[i].path, g_get_home_dir ()) == 0)
-		continue;
-	      
-	      /* If the old path is used by the new config, don't remove */
-	      entry = find_dir_entry_by_path (new_entries, old_entries[i].path);
-	      if (entry)
-		continue;
+        {
+          /* Change succeeded, remove any leftover empty directories */
+          for (i = 0; old_entries[i].type != NULL; i++)
+            {
+              /* Never remove homedir */
+              if (strcmp (old_entries[i].path, g_get_home_dir ()) == 0)
+                continue;
+              
+              /* If the old path is used by the new config, don't remove */
+              entry = find_dir_entry_by_path (new_entries, old_entries[i].path);
+              if (entry)
+                continue;
 
-	      /* Remove the dir, will fail if not empty */
-	      g_rmdir (old_entries[i].path);
-	    }
-	}
+              /* Remove the dir, will fail if not empty */
+              g_rmdir (old_entries[i].path);
+            }
+        }
     }
 
   if (should_save_locale)
@@ -394,64 +394,64 @@ main (int argc, char *argv[])
   if (bookmarks == NULL)
     {
       char *make_bm_for[] = {
-	"DOCUMENTS",
-	"MUSIC",
-	"PICTURES",
-	"VIDEOS",
-	"DOWNLOAD",
-	NULL};
+        "DOCUMENTS",
+        "MUSIC",
+        "PICTURES",
+        "VIDEOS",
+        "DOWNLOAD",
+        NULL};
       /* No previous bookmarks. Generate standard ones */
 
       desktop_entry = find_dir_entry (new_entries, "DESKTOP");
       for (i = 0; make_bm_for[i] != NULL; i++)
-	{
-	  entry = find_dir_entry (new_entries, make_bm_for[i]);
-	  
-	  if (entry && strcmp (entry->path, g_get_home_dir ()) != 0 &&
-	      (desktop_entry == NULL || strcmp (entry->path, desktop_entry->path) != 0))
-	    {
-	      uri = g_filename_to_uri (entry->path, NULL, NULL);
-	      if (uri)
-		{
-		  modified_bookmarks = TRUE;
-		  bookmark = g_new0 (GtkBookmark, 1);
-		  bookmark->uri = uri;
-		  bookmarks = g_list_append (bookmarks, bookmark);
-		}
-	    }
-	}
+        {
+          entry = find_dir_entry (new_entries, make_bm_for[i]);
+          
+          if (entry && strcmp (entry->path, g_get_home_dir ()) != 0 &&
+              (desktop_entry == NULL || strcmp (entry->path, desktop_entry->path) != 0))
+            {
+              uri = g_filename_to_uri (entry->path, NULL, NULL);
+              if (uri)
+                {
+                  modified_bookmarks = TRUE;
+                  bookmark = g_new0 (GtkBookmark, 1);
+                  bookmark->uri = uri;
+                  bookmarks = g_list_append (bookmarks, bookmark);
+                }
+            }
+        }
     }
   else
     {
       /* Map old bookmarks that were moved */
 
       for (l = bookmarks; l != NULL; l = l->next)
-	{
-	  char *path;
-	  
-	  bookmark = l->data;
+        {
+          char *path;
+          
+          bookmark = l->data;
 
-	  path = g_filename_from_uri (bookmark->uri, NULL, NULL);
-	  if (path)
-	    {
-	      entry = find_dir_entry_by_path (old_entries, path);
-	      if (entry)
-		{
-		  entry = find_dir_entry (new_entries, entry->type);
-		  if (entry)
-		    {
-		      uri = g_filename_to_uri (entry->path, NULL, NULL);
-		      if (uri)
-			{
-			  modified_bookmarks = TRUE;
-			  g_free (bookmark->uri);
-			  bookmark->uri = uri;
-			}
-		    }
-		}
-	      g_free (path);
-	    }
-	}
+          path = g_filename_from_uri (bookmark->uri, NULL, NULL);
+          if (path)
+            {
+              entry = find_dir_entry_by_path (old_entries, path);
+              if (entry)
+                {
+                  entry = find_dir_entry (new_entries, entry->type);
+                  if (entry)
+                    {
+                      uri = g_filename_to_uri (entry->path, NULL, NULL);
+                      if (uri)
+                        {
+                          modified_bookmarks = TRUE;
+                          g_free (bookmark->uri);
+                          bookmark->uri = uri;
+                        }
+                    }
+                }
+              g_free (path);
+            }
+        }
     }
 
   if (modified_bookmarks)

--- a/update.c
+++ b/update.c
@@ -168,7 +168,8 @@ do_run_dialog (GtkListStore *list_store,
       label = gtk_label_new (_("Note that existing content will not be moved."));
       gtk_label_set_line_wrap (GTK_LABEL (label), TRUE);
       gtk_label_set_selectable (GTK_LABEL (label), TRUE);
-      gtk_misc_set_alignment (GTK_MISC (label), 0.0, 0.0);
+      gtk_widget_set_halign (GTK_WIDGET (label), 0.0);
+      gtk_widget_set_valign (GTK_WIDGET (label), 0.0);
       gtk_widget_show (label);
       gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
     }


### PR DESCRIPTION
This should fix broken paths when locale change triggers a folder rename

[endlessm/eos-shell#2273]
