### PR TITLE
build: Distribute autogen.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,7 @@ INCLUDES =					\
 	$(NULL)
 
 EXTRA_DIST =					\
+	autogen.sh				\
         intltool-extract.in                     \
         intltool-merge.in                       \
         intltool-update.in                      \


### PR DESCRIPTION
Seems that it should be possible to regenerate the makefiles in a tarball
for a new version of autotools with the same script that one would use
for a git checkout.

https://phabricator.endlessm.com/T25372