### PR TITLE
Actually execute autogen.sh

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -7,4 +7,4 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1 -Wl,-z,defs -Wl,--as-needed
 	dh $@ --with gnome
 
 override_dh_autoreconf:
-	dh_autoreconf autogen.sh
+	dh_autoreconf ./autogen.sh


### PR DESCRIPTION
This should be squashed with af5fba33e7321aa9719dde183dbdd8401c2fea3a
when next porting the Debian commits forward.

https://phabricator.endlessm.com/T25372