### PR TITLE
Don't link to the sample media.

### DIFF
--- a/update.c
+++ b/update.c
@@ -536,9 +536,5 @@ main (int argc, char *argv[])
   g_free (new_entries);
   g_free (old_entries);
   
-  /* Run the script to link user directories to eos-media */
-  /* If script is not installed, simply ignore the error */
-  g_spawn_command_line_sync ("eos-link-user-dirs", NULL, NULL, NULL, NULL);
-
   return 0;
 }


### PR DESCRIPTION
The sample media isn't considered to be relevant anymore.Maintaining the
infrastructure is costly and a burden. Stop shipping the sample media
and turn off the server.

https://phabricator.endlessm.com/T30533